### PR TITLE
Ensure message is response message when executing sync query

### DIFF
--- a/src/kx/c.java
+++ b/src/kx/c.java
@@ -1236,15 +1236,19 @@ public class c{
    */
   public Object k() throws KException,IOException,UnsupportedEncodingException{
     synchronized(i){
-      i.readFully(b=new byte[8]); // read the msg header
-      a=b[0]==1;  // endianness of the msg 
+      processStream();
+      return deserialize(b);
+    }
+  }
+  
+  private void processStream() throws IOException {
+	  i.readFully(b=new byte[8]); // read the msg header
+      a=b[0]==1;  // endianness of the msg
       if(b[1]==1) // msg types are 0 - async, 1 - sync, 2 - response
         sync++;   // an incoming sync message means the remote will expect a response message
       j=4;
       b=Arrays.copyOf(b,ri());
       i.readFully(b,8,b.length-8); // read the incoming message in full
-      return deserialize(b);
-    }
   }
   /**
    * Sends a sync message to the remote kdb+ process. This blocks until the message has been sent in full, and a message

--- a/src/kx/c.java
+++ b/src/kx/c.java
@@ -63,21 +63,10 @@ public class c{
 
   /** Stream for printing kdb+ objects. Defaults to System.out */
   private static PrintStream out=System.out;
-  
-  /** Message mode - Legacy - process out of band message even when response expected */
-  public static final int MM_LGY = 0;
-  /** Message mode - Throw away - throw away out of band message when response expected */
-  public static final int MM_TA = 1;
   /**
    *  {@code sync}  tracks how many response messages the remote is expecting
    */
   private int sync=0;
-  
-  /**
-   * Tracks what to do with out of band messages when response expected. Default is to return out of band message 
-   */
-  private int msgMode = MM_LGY;
-  
   /**
    * Sets character encoding for serialising/deserialising strings.
    * 
@@ -140,18 +129,6 @@ public class c{
    * Indicates the type of message received. Msg types are 0 - async, 1 - sync, 2 - response
    */
   int msgType;
-  /**
-   * Sets the message mode. Valid modes are {@link #MM_LGY} or {@link #MM_TA}
-   * 
-   * @param msgMode Message mode. Valid modes {@link #MM_LGY} or {@link #MM_TA}
-   * @throws KException if msgMode greater than {@link #MM_TA} provided
-   */
-  public void setMsgMode(int msgMode) throws KException {
-    if(msgMode>MM_TA)
-      throw new KException("Invalid Msg Mode");
-    this.msgMode=Math.max(msgMode, 0);
-  }
-  
   /**
    * Sets whether or not to consider compression on outgoing messages.
    * 
@@ -1147,7 +1124,8 @@ public class c{
    * @param obj Object to send to the remote
    * 
    * @throws IOException if not expecting any response
-   */
+   */  
+  
   public void kr(Object obj) throws IOException{
     if(sync==0)
       throw new IOException("Unexpected response msg");
@@ -1287,15 +1265,10 @@ public class c{
    */
   public synchronized Object k(Object x) throws KException,IOException{
     w(1,x);
-    switch(msgMode){
-      case MM_TA:
-        Object d = k();
-        while(msgType<2)
-          d = k();
-        return d;
-      default:
-        return k();
-    }
+    Object d = k();
+    while(msgType<2)
+      d = k();
+    return d;
   }
   
   

--- a/src/kx/c.java
+++ b/src/kx/c.java
@@ -67,6 +67,7 @@ public class c{
    *  {@code sync}  tracks how many response messages the remote is expecting
    */
   private int sync=0;
+  
   /**
    * Sets character encoding for serialising/deserialising strings.
    * 
@@ -124,7 +125,6 @@ public class c{
    * Indicates whether messages should be candidates for compressing before sending.
    */
   boolean zip;
-
   /**
    * Indicates the type of message received. Msg types are 0 - async, 1 - sync, 2 - response
    */
@@ -1125,7 +1125,6 @@ public class c{
    * 
    * @throws IOException if not expecting any response
    */  
-  
   public void kr(Object obj) throws IOException{
     if(sync==0)
       throw new IOException("Unexpected response msg");
@@ -1252,7 +1251,6 @@ public class c{
       return deserialize(b);
     }
   }
-  
   /**
    * Sends a sync message to the remote kdb+ process. This blocks until the message has been sent in full, and a message
    * is received from the remote; typically the received message would be the corresponding response message.
@@ -1270,18 +1268,6 @@ public class c{
       d = k();
     return d;
   }
-  
-  
-      
-  
-//  public synchronized Object ker(Object x) throws KException, IOException{
-//    w(1,x);
-//    Object d = k();
-//    while(msgType < 2) {
-//      d= k(); // Only return is response
-//    }
-//    return d;
-//  }
   /**
    * Sends a sync message to the remote kdb+ process. This blocks until the message has been sent in full, and a message
    * is received from the remote; typically the received message would be the corresponding response message.

--- a/src/kx/c.java
+++ b/src/kx/c.java
@@ -67,7 +67,7 @@ public class c{
    *  {@code sync}  tracks how many response messages the remote is expecting
    */
   private int sync=0;
-  
+
   /**
    * Sets character encoding for serialising/deserialising strings.
    * 
@@ -1124,7 +1124,7 @@ public class c{
    * @param obj Object to send to the remote
    * 
    * @throws IOException if not expecting any response
-   */  
+   */
   public void kr(Object obj) throws IOException{
     if(sync==0)
       throw new IOException("Unexpected response msg");


### PR DESCRIPTION
@CharlieSkelton-Kx 
In the scenario where we have a Java remove client connecting to a q process;if an async message is sent to the java process; it will sit on the socket awaiting to be read. 

The issue is that if the Java process sends a query **c.k(new Object[]{"add", 3, 4})** the java process won't receive the result of the query; it will receive the async out of band message.

This change will check the msgType byte on the IPC message and ensure what is received is a response message; if not; it will throw away the message and read from the socket again (until a response message is received)