### PR TITLE
Further doc details & gitignore addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+docs/

--- a/src/kx/c.java
+++ b/src/kx/c.java
@@ -1290,6 +1290,8 @@ public class c{
   }
   /**
    * Returns the current msg handler 
+   *
+   * @return the current msg handler
    */
   public MsgHandler getMsgHandler(){
     return msgHandler;
@@ -1511,7 +1513,7 @@ public class c{
   }
   /** 
    * Current time in milliseconds 
-   * @return current time in millis.
+   * @return the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC(coordinated universal time).
    */
   public static long t(){
     return System.currentTimeMillis();


### PR DESCRIPTION
Building docs giving this warning

```
src\kx\c.java:1294: warning: no @return
  public MsgHandler getMsgHandler(){
```

Added gitignore for tmp build dirs to stop git thinking its none committed code.

Added further explaination of millisecond count from System.currentTimeMillis doc