### PR TITLE
Basic travis build file for testing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: java
+os: linux
+dist: trusty
+jdk:
+    - oraclejdk8
+    - oraclejdk9
+    - oraclejdk11
+    - oraclejdk12
+    - oraclejdk13
+    - oraclejdk14
+    - oraclejdk15
+    - openjdk8
+    - openjdk9
+    - openjdk10
+    - openjdk11
+    - openjdk12
+    - openjdk13
+    - openjdk14
+    - openjdk15
+script:
+    - make
+    - make doc


### PR DESCRIPTION
Basic build for to check the interface builds on java 8 to java 15 (note: oraclejdk10 not on build boxes).
Uses travis io. 
Can then be used to auto check any pull requests/etc dont break anything & currently exposes some new warnings/etc.
Checked with copy of repo.