### PR TITLE
Jacoco used for test coverage. Closes #19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,12 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <jacoco.version>0.8.3</jacoco.version>
+    <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+    <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+    <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
+    <sonar.language>java</sonar.language>
+    <sonar.coverage.exclusions>**/kx/examples/*</sonar.coverage.exclusions>
   </properties>
 
   <dependencies>
@@ -25,5 +31,41 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
+          <configuration>
+              <skip>${maven.test.skip}</skip>
+              <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
+              <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
+              <output>file</output>
+              <append>false</append>
+              <excludes>
+                  <exclude>**/kx/examples/*</exclude>
+              </excludes>
+          </configuration>
+          <executions>
+              <execution>
+                  <id>jacoco-initialize</id>
+                  <goals>
+                      <goal>prepare-agent</goal>
+                  </goals>
+                  <phase>test-compile</phase>
+              </execution>
+              <execution>
+                  <id>jacoco-site</id>
+                  <phase>verify</phase>
+                  <goals>
+                      <goal>report</goal>
+                  </goals>
+              </execution>
+          </executions>
+        </plugin>
+      </plugins>
+  </build>
 
  </project>

--- a/src/test/java/kx/cTest.java
+++ b/src/test/java/kx/cTest.java
@@ -3,10 +3,12 @@ package kx;
 import static org.junit.Assert.assertTrue;
 
 import java.util.UUID;
+import java.util.Arrays;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import org.junit.Test;
+import org.junit.Assert;
 
 /**
  * Unit test for c.java.
@@ -184,5 +186,36 @@ public class cTest
         c.Dict dict = new c.Dict(x, y);
         c.Flip flip = new c.Flip(dict);
         flip.at("RUBBISH");
+    }
+
+    @Test
+    public void testSerializeDeserialize()
+    {
+        kx.c c=new kx.c();
+        int[]input=new int[50000];
+        for(int i=0;i<input.length;i++)
+            input[i]=i%10;
+        try{
+            assertTrue(Arrays.equals(input,(int[])c.deserialize(c.serialize(1,input,false))));
+            assertTrue(Arrays.equals(input,(int[])c.deserialize(c.serialize(1,input,true))));
+        } catch (Exception e) {
+            Assert.fail(e.toString());
+        }
+    }
+
+    @Test
+    public void testCompressBoolList()
+    {
+        boolean[] data = new boolean[2000];
+        for(int i=0;i<data.length;i++)
+            data[i]=true;
+        byte[] compressedBools = {(byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x26, (byte)0x00, (byte)0x00, (byte)0x07, (byte)0xde, (byte)0x00, (byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x07, (byte)0xd0, (byte)0x01, (byte)0x01, (byte)0xff, (byte)0x00, (byte)0xff, (byte)0x00, (byte)0xff, (byte)0x00, (byte)0xff, (byte)0x00, (byte)0xff, (byte)0x00, (byte)0xff, (byte)0x00, (byte)0xff, (byte)0x00, (byte)0xff, (byte)0x00, (byte)0xc5};
+        kx.c c=new kx.c();
+        try{
+            byte[] compressed = c.serialize(0,data,true);
+            assertTrue(Arrays.equals(compressed,compressedBools));
+        } catch (Exception e) {
+            Assert.fail(e.toString());
+        }
     }
 }


### PR DESCRIPTION
Ability to use jacoco plugin with maven for reporting what code is or isnt tested in the unit tests (currently 32%).
Addition of an extra test.
Works with sonarqube for graphing/etc results.