### PR TITLE
Moved setup code from Feed.java to docs. Ref: #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ Creates a Swing GUI that presents the contents of a KDB+ table (Flip).  It shows
 
 Prerequisite: 
 
-a KDB+ server running on port 5001 on your machine i.e. q -p 5001
+- a KDB+ server running on port 5001 on your machine i.e. q -p 5001
+
 
 Run command:
 
-`mvn exec:java -Dexec.mainClass="kx.examples.GridViewer"`
+- `mvn exec:java -Dexec.mainClass="kx.examples.GridViewer"`
 
 ### QueryResponse
 
@@ -56,11 +57,12 @@ Instructs the remote KDB+ process to execute 'q' code (KDB+ native language) & r
 
 Prerequisite:
 
-a KDB+ server running on port 5001 on your machine i.e. q -p 5001
+- a KDB+ server running on port 5001 on your machine i.e. q -p 5001
+
 
 Run command:
 
-`mvn exec:java -Dexec.mainClass="kx.examples.QueryResponse"`
+- `mvn exec:java -Dexec.mainClass="kx.examples.QueryResponse"`
 
 ### SerializationOnly
 
@@ -68,7 +70,7 @@ Example of code that can be used to serialize/dezerialise a Java type (array of 
 
 Run command:
 
-`mvn exec:java -Dexec.mainClass="kx.examples.SerializationOnly"`
+- `mvn exec:java -Dexec.mainClass="kx.examples.SerializationOnly"`
 
 ### Server
 
@@ -82,7 +84,7 @@ q)neg[h]"hello"
 
 Run command
 
-`mvn exec:java -Dexec.mainClass="kx.examples.Server"`
+- `mvn exec:java -Dexec.mainClass="kx.examples.Server"`
 
 ### Feed
 
@@ -91,11 +93,18 @@ Table population has an example of single row inserts (lower latency) and bulk i
 
 Prerequisite: 
 
-a KDB+ server running on port 5010 on your machine i.e. q -p 5010
+- a KDB+ server running on port 5010 on your machine i.e. q -p 5010. 
+
+- as this example depends on a .u.upd function being defined and a table name 'mytable' pre-existing, you may wish to run the following within the KDB+ server (in normal environments, these table and function definitions should be pre-created by your KDB+ admin). 
+
+  ``
+  q).u.upd:{[tbl;row] insert[tbl](row)}
+  q)mytable:([]time:`timespan$();sym:`symbol$();price:`float$();size:`long$())
+  ``
 
 Run command
 
-`mvn exec:java -Dexec.mainClass="kx.examples.Feed"`
+- `mvn exec:java -Dexec.mainClass="kx.examples.Feed"`
 
 ### TypesMapping
 
@@ -103,8 +112,9 @@ Example app that creates each of the KDB+ types in Java, and communicates with K
 
 Prerequisite: 
 
-a KDB+ server running on port 5010 on your machine i.e. q -p 5010
+- a KDB+ server running on port 5010 on your machine i.e. q -p 5010
+
 
 Run command:
 
-`mvn exec:java -Dexec.mainClass="kx.examples.TypesMapping"`
+- `mvn exec:java -Dexec.mainClass="kx.examples.TypesMapping"`

--- a/src/main/java/kx/examples/Feed.java
+++ b/src/main/java/kx/examples/Feed.java
@@ -10,40 +10,6 @@ public class Feed{
   private static final String TABLENAME = "mytable";
 
   /**
-  * Create a function called .u.upd. This function tables 2 parameters
-  * 1. name of the table
-  * 2. row for the table
-  * When it gets an update, it will insert a row into a table.
-  * You could pass the function definition into the program or allow kdb to define it.
-  * This could allow the function to do other things with the data without
-  * rewritting your code/etc
-  * @param kconn Connection that will be sent the .u.upd function
-  */
-  static void createUpdateCmd(c kconn){
-    LOGGER.log(Level.INFO,"Creating .u.upd function on kdb server...");
-    try {
-      kconn.k(".u.upd:{[tbl;row] insert[tbl](row)}");
-    } catch (Exception e) {
-      LOGGER.log(Level.SEVERE,e.toString());
-      System.exit(-1);
-    }
-  }
-
-  /**
-   * Creates a table for future inserts
-   * @param kconn Connection that will be sent the inserts
-   */
-  static void createTable(c kconn) {
-    LOGGER.log(Level.INFO,"Creating 'mytable' on kdb server...");
-    try {
-      kconn.k("mytable:([]time:`timespan$();sym:`symbol$();price:`float$();size:`long$())");
-    } catch (Exception e) {
-      LOGGER.log(Level.SEVERE,e.toString());
-      System.exit(-1);
-    }
-  }
-
-  /**
    * Example of 10 single row inserts to a table
    * @param kconn Connection that will be sent the inserts
    * @throws java.io.IOException when issue with KDB+ comms
@@ -94,8 +60,6 @@ public class Feed{
     c c=null;
     try{
       c=new c("localhost",5010,System.getProperty("user.name")+":mypassword");
-      createUpdateCmd(c);
-      createTable(c);
       rowInserts(c);
       bulkInserts(c);
     }


### PR DESCRIPTION
Removed code to prerequisite section of docs. 
Aims to help non-q dev & java only dev get an example running.
In a situation were a java dev is trying KDB+ for the first time, or no access to a fully fledged env, should give enough info to get it running.