### PR TITLE
Remove jacoco binary report to fix sonar warning. Fixes #45

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
           <source>8</source>
         </configuration>
         <executions>
-	        <execution>
+          <execution>
             <id>attach-javadocs</id>
             <goals>
               <goal>jar</goal>
@@ -80,7 +80,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-	      <version>3.2.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
     <jacoco.version>0.8.3</jacoco.version>
     <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-    <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
     <sonar.language>java</sonar.language>
     <sonar.coverage.exclusions>**/kx/examples/*</sonar.coverage.exclusions>
   </properties>
@@ -70,7 +69,7 @@
           <source>8</source>
         </configuration>
         <executions>
-	  <execution>
+	        <execution>
             <id>attach-javadocs</id>
             <goals>
               <goal>jar</goal>
@@ -81,7 +80,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-	<version>3.2.1</version>
+	      <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>


### PR DESCRIPTION
Sonar GUI has a warning when report submitted - remove this use allows it to default to an XML report & appears to stop the warning.