### PR TITLE
Updated jacoco version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <jacoco.version>0.8.3</jacoco.version>
+    <jacoco.version>0.8.8</jacoco.version>
     <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
     <sonar.language>java</sonar.language>


### PR DESCRIPTION
Getting errors such as the following when running mvn test
```
Running kx.cTest
java.lang.instrument.IllegalClassFormatException: Error while instrumenting java/sql/Timestamp.
	at org.jacoco.agent.rt.internal_1f1cc91.CoverageTransformer.transform(CoverageTransformer.java:93)
```
when using Java version: 18.0.2, mvn 3.8.5

Also tested with 
`docker run -it --rm -v ./javakdb:/src -w /src  maven:3.6-openjdk-11`