### PR TITLE
Remove warnings when creating package due to docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <version>3.2.0</version>
         <configuration>
           <source>8</source>
+          <quiet>true</quiet>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/kx/examples/Feed.java
+++ b/src/main/java/kx/examples/Feed.java
@@ -3,12 +3,17 @@ import kx.c;
 import java.security.SecureRandom;
 import java.util.logging.Logger;
 import java.util.logging.Level;
-
+/**
+ * Example of creating an update function remotely (to capture table inserts), 
+ * along with table creation and population of the table. 
+ * Table population has an example of single row inserts (lower latency) and 
+ * bulk inserts (better throughput and resource utilization).
+ */
 public class Feed{
   private static final Logger LOGGER = Logger.getLogger(Feed.class.getName());
   private static final String QFUNC = ".u.upd";
   private static final String TABLENAME = "mytable";
-
+  private Feed(){}
   /**
    * Example of 10 single row inserts to a table
    * @param kconn Connection that will be sent the inserts
@@ -56,7 +61,13 @@ public class Feed{
     kconn.k(""); // sync chase ensures the remote has processed all msgs
   }
 
-  public static void main(String[] args){// example tick feed
+  /**
+   * Run example tick feed
+   * Requires a KDB+ server running on port 5010 on your machine i.e. q -p 5010
+   * Depends on a .u.upd function being defined and a table name 'mytable' pre-existing
+   * @param args not used
+   */
+  public static void main(String[] args){
     c c=null;
     try{
       c=new c("localhost",5010,System.getProperty("user.name")+":mypassword");

--- a/src/main/java/kx/examples/GridViewer.java
+++ b/src/main/java/kx/examples/GridViewer.java
@@ -11,11 +11,17 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
 import kx.c;
-
+/**
+ * Creates a Swing GUI that presents the contents of a KDB+ table (Flip). 
+ * It shows the mapping of the Flip class to a Swing TableModel. 
+ * The contents of the table are some random data that we instruct KDB+ to generate.
+ */
 public class GridViewer {
-    public static class KxTableModel extends AbstractTableModel {
+    private GridViewer(){}
+    static class KxTableModel extends AbstractTableModel {
+        /** kdb table to display in gui as result of query */
         private c.Flip flip;
-        public void setFlip(c.Flip data) {
+        void setFlip(c.Flip data) {
             this.flip = data;
         }
 
@@ -37,6 +43,11 @@ public class GridViewer {
         }
     }
 
+    /**
+     * Creates a GUI to show contents of a table from KDB+
+     * Requires a KDB+ server running on port 5001 on your machine i.e. q -p 5001
+     * @param args not used
+     */
     public static void main(String[] args) {
         KxTableModel model = new KxTableModel();
         c c = null;

--- a/src/main/java/kx/examples/QueryResponse.java
+++ b/src/main/java/kx/examples/QueryResponse.java
@@ -2,8 +2,18 @@ package kx.examples;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import kx.c;
+/**
+ * Instructs the remote KDB+ process to execute 'q' code (KDB+ native language) and 
+ * receives the result. The same principle can be used to execute q functions
+ */
 public class QueryResponse{
   private static final Logger LOGGER = Logger.getLogger(QueryResponse.class.getName());
+  private QueryResponse(){}
+  /**
+   * Runs a calcuation on remote KDB+ server and prints result to console
+   * Requires a KDB+ server running on port 5001 on your machine i.e. q -p 5001
+   * @param args not used
+   */
   public static void main(String[] args){
     c c=null;
     try{

--- a/src/main/java/kx/examples/SerializationOnly.java
+++ b/src/main/java/kx/examples/SerializationOnly.java
@@ -1,20 +1,20 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 package kx.examples;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import kx.c;
 /**
- @author charlie
+ * Example of code that can be used to serialize/dezerialise a Java type (array of ints) to KDB+ format.
+ * @author charlie
  */
 public class SerializationOnly{
   private static final Logger LOGGER = Logger.getLogger(SerializationOnly.class.getName());
-  
+  private SerializationOnly(){}
+  /**
+   * Runs program and prints whether serialization/deserialization of an
+   * integer array match.
+   * @param s not used
+   */
   public static void main(String[]s){
     c c=new c();
     int[]input=new int[50000];

--- a/src/main/java/kx/examples/Server.java
+++ b/src/main/java/kx/examples/Server.java
@@ -3,8 +3,13 @@ import java.net.*;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import kx.c;
+/**
+ * Creates a Java apps that listens on TCP port 5010, which a KDB+ process 
+ * can communicate with. It will echo back sync messages and discard async messages. 
+ */
 public class Server{
   private static final Logger LOGGER = Logger.getLogger(Server.class.getName());
+  private Server(){}
 
   private static class ServerC extends c implements AutoCloseable{
     ServerC(ServerSocket s)throws java.io.IOException{super(s);}
@@ -19,7 +24,11 @@ public class Server{
     }
     }
   }
-  public static void main(String[] args){// example echo server for a single client
+  /**
+   * Run example echo server for a single client
+   * @param args not used
+   */
+  public static void main(String[] args){
     int port=5010;
     try (ServerC c = new ServerC(new ServerSocket(port))) {
       boolean ok = true;

--- a/src/main/java/kx/examples/Subscriber.java
+++ b/src/main/java/kx/examples/Subscriber.java
@@ -3,11 +3,21 @@ package kx.examples;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import kx.c;
-
+/**
+ * Example app that subscribes to real-time updates from a table that 
+ * is maintained in KDB+.
+ */
 public class Subscriber{
   private static final Logger LOGGER = Logger.getLogger(Subscriber.class.getName());
+  private Subscriber(){}
 
-  public static void main(String[] args){// example tick subscriber
+  /**
+   * Run example tick subscriber
+   * Requires a KDB+ server running on port 5010 on your machine. 
+   * The KDB+ instance must have the .u.sub function defined
+   * @param args not used
+   */
+  public static void main(String[] args){
     c c=null;
     try{
       c=new c("localhost",5010,System.getProperty("user.name")+":mypassword");

--- a/src/main/java/kx/examples/TypesMapping.java
+++ b/src/main/java/kx/examples/TypesMapping.java
@@ -9,8 +9,16 @@ import java.sql.Timestamp;
 import java.sql.Date;
 import java.sql.Time;
 import java.util.UUID;
+/**
+ * Example app that creates each of the KDB+ types in Java, 
+ * and communicates with KDB+ to check that the type has been correctly matched 
+ * with its 'q' type (KDB+ default language). 
+ * Prints the Java type and corresponding 'q' type.
+ */
 public class TypesMapping{
   private static final Logger LOGGER = Logger.getLogger(TypesMapping.class.getName());
+  
+  private TypesMapping(){}
 
   static Date dateNow(){
     Calendar calendar=Calendar.getInstance();
@@ -37,6 +45,12 @@ public class TypesMapping{
       result+="table";
     return result;
   }
+  /**
+   * Runs program to check Java types against q types on KDB+.
+   * Prints results to console.
+   * Requires KDB+ server running on port 5010 on your machine i.e. q -p 5010
+   * @param args not used
+   */
   public static void main(String[] args){
     c c=null;
     try{


### PR DESCRIPTION
When doing `mvn clean package` created various warnings when creating javadocs e.g.

```
[INFO] --- maven-javadoc-plugin:3.2.0:jar (attach-javadocs) @ javakdb ---
[INFO] No previous run data found, generating javadoc.
[WARNING] Javadoc Warnings
[WARNING] Loading source files for package kx...
[WARNING] Loading source files for package kx.examples...
[WARNING] Constructing Javadoc information...
[WARNING] Building index for all the packages and classes...
[WARNING] Standard Doclet version 18.0.2+0
[WARNING] Building tree for all the packages and classes...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/c.html...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/c.Dict.html...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/c.Flip.html...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/c.IAuthenticate.html...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/c.KException.html...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/c.Minute.html...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/c.Month.html...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/c.MsgHandler.html...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/c.Second.html...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/c.Timespan.html...
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/examples/Feed.html...
[WARNING] /Users/simon/Development/javakdb2/javakdb/src/main/java/kx/examples/Feed.java:12: warning: use of default constructor, which does not provide a comment
[WARNING] public class Feed{
[WARNING] ^
[WARNING] Generating /Users/simon/Development/javakdb2/javakdb/target/apidocs/kx/examples/GridViewer.html...
[WARNING] /Users/simon/Development/javakdb2/javakdb/src/main/java/kx/examples/GridViewer.java:20: warning: no comment
[WARNING] public static class KxTableModel extends AbstractTableModel {
[WARNING] ^
[WARNING] /Users/simon/Development/javakdb2/javakdb/src/main/java/kx/examples/GridViewer.java:19: warning: use of default constructor, which does not provide a comment
[WARNING] public class GridViewer {
[WARNING] ^
```
etc