### PR TITLE
Changes to use java.time classes

### DIFF
--- a/src/main/java/kx/examples/TypesMapping.java
+++ b/src/main/java/kx/examples/TypesMapping.java
@@ -2,12 +2,13 @@ package kx.examples;
 import kx.c;
 import java.util.logging.Logger;
 import java.util.logging.Level;
-import java.util.Calendar;
 import java.lang.reflect.Array;
 import java.util.Arrays;
-import java.sql.Timestamp;
-import java.sql.Date;
-import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 /**
  * Example app that creates each of the KDB+ types in Java, 
@@ -20,19 +21,6 @@ public class TypesMapping{
   
   private TypesMapping(){}
 
-  static Date dateNow(){
-    Calendar calendar=Calendar.getInstance();
-    calendar.set(Calendar.HOUR_OF_DAY,0);
-    calendar.set(Calendar.MINUTE,0);
-    calendar.set(Calendar.SECOND,0);
-    calendar.set(Calendar.MILLISECOND,0);
-    return new Date(calendar.getTime().getTime());
-  }
-  static Time timeNow(){
-    Calendar calendar=Calendar.getInstance();
-    calendar.set(1970,0,1);
-    return new Time(calendar.getTime().getTime());
-  }
   static String getKTypeAsString(short i){
     String result="("+i+")";
     String[]types={"list","boolean","guid","","byte","short","int","long","real","float","char",
@@ -66,14 +54,14 @@ public class TypesMapping{
         new double[]{42.42d},
         new char[]{'a'},
         new String[]{"42"},
-        new Timestamp[]{new Timestamp(Calendar.getInstance().getTime().getTime())},
+        new Instant[]{Instant.now().plusNanos(1)},
         new c.Month[]{new c.Month(11)},
-        new Date[]{dateNow()},
-        new java.util.Date[]{new java.util.Date()}, // datetime
+        new LocalDate[]{LocalDate.now()},
+        new LocalDateTime[]{LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)}, // datetime
         new c.Timespan[]{new c.Timespan()},
-        new c.Minute[]{new c.Minute((int)timeNow().getTime()/60000)},
-        new c.Second[]{new c.Second((int)timeNow().getTime()/1000)},
-        new Time[]{timeNow()}};
+        new c.Minute[]{new c.Minute(LocalDateTime.now().getMinute())},
+        new c.Second[]{new c.Second(LocalDateTime.now().getSecond())},
+        new LocalTime[]{LocalTime.now().truncatedTo(ChronoUnit.MILLIS)}};
       String format="|%21s|%21s|%38s|%38s|%5s|\n";
       LOGGER.log(Level.INFO,"{0}",String.format(format,"Java Type","kdb+ Type","Value Sent","kdb+ Value","Match"));
       LOGGER.log(Level.INFO,"{0}",String.format(format,"","","","","").replace(' ', '-'));

--- a/src/test/java/kx/cTest.java
+++ b/src/test/java/kx/cTest.java
@@ -4,9 +4,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.UUID;
 import java.util.Arrays;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
+import java.time.LocalTime;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import org.junit.Test;
 import org.junit.Assert;
 
@@ -30,14 +33,14 @@ public class cTest
         Assert.assertEquals(Double.NaN,c.NULL[9]);
         Assert.assertEquals(' ',c.NULL[10]);
         Assert.assertEquals("",c.NULL[11]);
-        Assert.assertEquals(new Timestamp(Long.MIN_VALUE),c.NULL[12]);
+        Assert.assertEquals(Instant.MIN,c.NULL[12]);
         Assert.assertEquals(new c.Month(Integer.MIN_VALUE),c.NULL[13]);
-        Assert.assertEquals(new Date(Long.MIN_VALUE),c.NULL[14]);
-        Assert.assertEquals(new java.util.Date(Long.MIN_VALUE),c.NULL[15]);
+        Assert.assertEquals(LocalDate.MIN,c.NULL[14]);
+        Assert.assertEquals(LocalDateTime.MIN,c.NULL[15]);
         Assert.assertEquals(new c.Timespan(Long.MIN_VALUE),c.NULL[16]);
         Assert.assertEquals(new c.Minute(Integer.MIN_VALUE),c.NULL[17]);
         Assert.assertEquals(new c.Second(Integer.MIN_VALUE),c.NULL[18]);
-        Assert.assertEquals(new Time(Long.MIN_VALUE),c.NULL[19]);
+        Assert.assertEquals(kx.c.LOCAL_TIME_NULL,c.NULL[19]);
     }
 
     @Test
@@ -54,14 +57,14 @@ public class cTest
         Assert.assertEquals(Double.NaN, c.NULL('f'));
         Assert.assertEquals(' ', c.NULL('c'));
         Assert.assertEquals("", c.NULL('s'));
-        Assert.assertEquals(new Timestamp(Long.MIN_VALUE), c.NULL('p'));
+        Assert.assertEquals(Instant.MIN, c.NULL('p'));
         Assert.assertEquals(new c.Month(Integer.MIN_VALUE), c.NULL('m'));
-        Assert.assertEquals(new Date(Long.MIN_VALUE), c.NULL('d'));
-        Assert.assertEquals(new java.util.Date(Long.MIN_VALUE), c.NULL('z'));
+        Assert.assertEquals(LocalDate.MIN, c.NULL('d'));
+        Assert.assertEquals(LocalDateTime.MIN, c.NULL('z'));
         Assert.assertEquals(new c.Timespan(Long.MIN_VALUE), c.NULL('n'));
         Assert.assertEquals(new c.Minute(Integer.MIN_VALUE), c.NULL('u'));
         Assert.assertEquals(new c.Second(Integer.MIN_VALUE), c.NULL('v'));
-        Assert.assertEquals(new Time(Long.MIN_VALUE), c.NULL('t'));
+        Assert.assertEquals(kx.c.LOCAL_TIME_NULL, c.NULL('t'));
     }
 
     @Test
@@ -80,14 +83,14 @@ public class cTest
     {
         assertTrue( c.qn("") );
         Assert.assertEquals(false, c.qn(" "));
-        assertTrue( c.qn(new Timestamp(Long.MIN_VALUE)));
+        assertTrue( c.qn(Instant.MIN));
         assertTrue( c.qn(new c.Month(Integer.MIN_VALUE)));
-        assertTrue( c.qn(new Date(Long.MIN_VALUE)));
-        assertTrue( c.qn(new java.util.Date(Long.MIN_VALUE)));
+        assertTrue( c.qn(LocalDate.MIN));
+        assertTrue( c.qn(LocalDateTime.MIN));
         assertTrue( c.qn(new c.Timespan(Long.MIN_VALUE)));
         assertTrue( c.qn(new c.Minute(Integer.MIN_VALUE)));
         assertTrue( c.qn(new c.Second(Integer.MIN_VALUE)));
-        assertTrue( c.qn(new Time(Long.MIN_VALUE)) );
+        assertTrue( c.qn(kx.c.LOCAL_TIME_NULL) );
         assertTrue( c.qn(kx.c.NULL('g')));
     }
 
@@ -111,10 +114,10 @@ public class cTest
         Assert.assertEquals(-9, c.t(Double.valueOf(1.2)));
         Assert.assertEquals(-10, c.t(Character.valueOf(' ')));
         Assert.assertEquals(-11, c.t(""));
-        Assert.assertEquals(-14, c.t(new Date(Long.MIN_VALUE)));
-        Assert.assertEquals(-19, c.t(new Time(Long.MIN_VALUE)));
-        Assert.assertEquals(-12, c.t(new Timestamp(Long.MIN_VALUE)));
-        Assert.assertEquals(-15, c.t(new java.util.Date(Long.MIN_VALUE)));
+        Assert.assertEquals(-14, c.t(LocalDate.MIN));
+        Assert.assertEquals(-19, c.t(kx.c.LOCAL_TIME_NULL));
+        Assert.assertEquals(-12, c.t(Instant.MIN));
+        Assert.assertEquals(-15, c.t(LocalDateTime.MIN));
         Assert.assertEquals(-16, c.t(new c.Timespan(Long.MIN_VALUE)));
         Assert.assertEquals(-13, c.t(new c.Month(Integer.MIN_VALUE)));
         Assert.assertEquals(-17, c.t(new c.Minute(Integer.MIN_VALUE)));
@@ -134,10 +137,10 @@ public class cTest
         Assert.assertEquals(9, c.t(new double[2]));
         Assert.assertEquals(10, c.t(new char[2]));
         Assert.assertEquals(11, c.t(new String[2]));
-        Assert.assertEquals(14, c.t(new Date[2]));
-        Assert.assertEquals(19, c.t(new Time[2]));
-        Assert.assertEquals(12, c.t(new Timestamp[2]));
-        Assert.assertEquals(15, c.t(new java.util.Date[2]));
+        Assert.assertEquals(14, c.t(new LocalDate[2]));
+        Assert.assertEquals(19, c.t(new LocalTime[2]));
+        Assert.assertEquals(12, c.t(new Instant[2]));
+        Assert.assertEquals(15, c.t(new LocalDateTime[2]));
         Assert.assertEquals(16, c.t(new c.Timespan[2]));
         Assert.assertEquals(13, c.t(new c.Month[2]));
         Assert.assertEquals(17, c.t(new c.Minute[2]));
@@ -372,25 +375,43 @@ public class cTest
     }
 
     @Test
-    public void testSerializeDeserializeDate()
+    public void testSerializeDeserializeLocalDate()
     {
         kx.c c=new kx.c();
-        Date input=new Date(86400000000000L);
+        LocalDate input=LocalDate.ofEpochDay(Integer.MAX_VALUE);
         try{
-            Assert.assertEquals(input,(Date)c.deserialize(c.serialize(1,input,false)));
-            Assert.assertEquals(input,(Date)c.deserialize(c.serialize(1,input,true)));
+            Assert.assertEquals(input,(LocalDate)c.deserialize(c.serialize(1,input,false)));
+            Assert.assertEquals(input,(LocalDate)c.deserialize(c.serialize(1,input,true)));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
-        input=new Date(Long.MIN_VALUE);
+        input=LocalDate.MIN;
         try{
-            Assert.assertEquals(input,(Date)c.deserialize(c.serialize(1,input,false)));
-            Assert.assertEquals(input,(Date)c.deserialize(c.serialize(1,input,true)));
+            Assert.assertEquals(input,(LocalDate)c.deserialize(c.serialize(1,input,false)));
+            Assert.assertEquals(input,(LocalDate)c.deserialize(c.serialize(1,input,true)));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
         try{
-            Assert.assertEquals(kx.c.NULL[14],(java.util.Date)c.deserialize(c.serialize(1,kx.c.NULL[14],true)));
+            Assert.assertEquals(kx.c.NULL[14],(LocalDate)c.deserialize(c.serialize(1,kx.c.NULL[14],true)));
+        } catch (Exception e) {
+            Assert.fail(e.toString());
+        }
+        input=LocalDate.ofEpochDay(Integer.MAX_VALUE+1);
+        try{
+            c.serialize(1,input,true);
+            Assert.fail("Expected a RuntimeException to be thrown");
+        } catch(RuntimeException e) {
+            // expected
+        } catch (Exception e) {
+            Assert.fail(e.toString());
+        }
+        input=LocalDate.ofEpochDay(Integer.MIN_VALUE-1L-kx.c.DAYS_BETWEEN_1970_2000);
+        try{
+            c.serialize(1,input,true);
+            Assert.fail("Expected a RuntimeException to be thrown");
+        } catch(RuntimeException e) {
+            // expected
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
@@ -400,44 +421,44 @@ public class cTest
     public void testSerializeDeserializeTime()
     {
         kx.c c=new kx.c();
-        Time input=new Time(55);
+        LocalTime input=LocalTime.of(12,10,1,1000000*5);;
         try{
-            Assert.assertEquals(input,(Time)c.deserialize(c.serialize(1,input,false)));
-            Assert.assertEquals(input,(Time)c.deserialize(c.serialize(1,input,true)));
+            Assert.assertEquals(input,(LocalTime)c.deserialize(c.serialize(1,input,false)));
+            Assert.assertEquals(input,(LocalTime)c.deserialize(c.serialize(1,input,true)));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
-        input=new Time(Long.MIN_VALUE);
+        input=kx.c.LOCAL_TIME_NULL;
         try{
-            Assert.assertEquals(input,(Time)c.deserialize(c.serialize(1,input,false)));
-            Assert.assertEquals(input,(Time)c.deserialize(c.serialize(1,input,true)));
+            Assert.assertEquals(input,(LocalTime)c.deserialize(c.serialize(1,input,false)));
+            Assert.assertEquals(input,(LocalTime)c.deserialize(c.serialize(1,input,true)));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
     }
 
     @Test
-    public void testSerializeDeserializeTimestamp()
+    public void testSerializeDeserializeInstant()
     {
         kx.c c=new kx.c();
-        Timestamp input=new Timestamp(55);
+        Instant input=Instant.ofEpochMilli(55);
         try{
-            Assert.assertEquals(input,(Timestamp)c.deserialize(c.serialize(1,input,false)));
-            Assert.assertEquals(input,(Timestamp)c.deserialize(c.serialize(1,input,true)));
+            Assert.assertEquals(input,(Instant)c.deserialize(c.serialize(1,input,false)));
+            Assert.assertEquals(input,(Instant)c.deserialize(c.serialize(1,input,true)));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
-        input=new Timestamp(86400000L*10957L+10);
+        input=Instant.ofEpochMilli(86400000L*10957L+10);
         try{
-            Assert.assertEquals(input,(Timestamp)c.deserialize(c.serialize(1,input,false)));
-            Assert.assertEquals(input,(Timestamp)c.deserialize(c.serialize(1,input,true)));
+            Assert.assertEquals(input,(Instant)c.deserialize(c.serialize(1,input,false)));
+            Assert.assertEquals(input,(Instant)c.deserialize(c.serialize(1,input,true)));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
-        input=new Timestamp(Long.MIN_VALUE);
+        input=Instant.MIN;
         try{
-            Assert.assertEquals(input,(Timestamp)c.deserialize(c.serialize(1,input,false)));
-            Assert.assertEquals(input,(Timestamp)c.deserialize(c.serialize(1,input,true)));
+            Assert.assertEquals(input,(Instant)c.deserialize(c.serialize(1,input,false)));
+            Assert.assertEquals(input,(Instant)c.deserialize(c.serialize(1,input,true)));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
@@ -458,10 +479,11 @@ public class cTest
     {
         kx.c c=new kx.c();
         try{
-            java.util.Date input=new java.text.SimpleDateFormat("dd/MM/yyyy").parse("01/01/1990");
-            Assert.assertEquals(input,(java.util.Date)c.deserialize(c.serialize(1,input,false)));
-            Assert.assertEquals(input,(java.util.Date)c.deserialize(c.serialize(1,input,true)));
-            Assert.assertEquals(kx.c.NULL[15],(java.util.Date)c.deserialize(c.serialize(1,kx.c.NULL[15],true)));
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+            LocalDateTime input = LocalDate.parse("01/01/1990", formatter).atStartOfDay();
+            Assert.assertEquals(input,(LocalDateTime)c.deserialize(c.serialize(1,input,false)));
+            Assert.assertEquals(input,(LocalDateTime)c.deserialize(c.serialize(1,input,true)));
+            Assert.assertEquals(kx.c.NULL[15],(LocalDateTime)c.deserialize(c.serialize(1,kx.c.NULL[15],true)));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
@@ -688,12 +710,12 @@ public class cTest
     public void testSerializeDeserializeDateArray()
     {
         kx.c c=new kx.c();
-        Date[]input=new Date[50];
+        LocalDate[]input=new LocalDate[50];
         for(int i=0;i<input.length;i++)
-            input[i]=new Date(86400000000000L);
+            input[i]=LocalDate.ofEpochDay(Integer.MAX_VALUE);
         try{
-            assertTrue(Arrays.equals(input,(Date[])c.deserialize(c.serialize(1,input,false))));
-            assertTrue(Arrays.equals(input,(Date[])c.deserialize(c.serialize(1,input,true))));
+            assertTrue(Arrays.equals(input,(LocalDate[])c.deserialize(c.serialize(1,input,false))));
+            assertTrue(Arrays.equals(input,(LocalDate[])c.deserialize(c.serialize(1,input,true))));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
@@ -703,27 +725,27 @@ public class cTest
     public void testSerializeDeserializeTimeArray()
     {
         kx.c c=new kx.c();
-        Time[]input=new Time[50];
+        LocalTime[]input=new LocalTime[50];
         for(int i=0;i<input.length;i++)
-            input[i]=new Time(1);
+            input[i]=LocalDateTime.ofInstant(Instant.ofEpochMilli(1),ZoneId.of("UTC")).toLocalTime();
         try{
-            assertTrue(Arrays.equals(input,(Time[])c.deserialize(c.serialize(1,input,false))));
-            assertTrue(Arrays.equals(input,(Time[])c.deserialize(c.serialize(1,input,true))));
+            assertTrue(Arrays.equals(input,(LocalTime[])c.deserialize(c.serialize(1,input,false))));
+            assertTrue(Arrays.equals(input,(LocalTime[])c.deserialize(c.serialize(1,input,true))));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
     }
 
     @Test
-    public void testSerializeDeserializeTimestampArray()
+    public void testSerializeDeserializeInstantArray()
     {
         kx.c c=new kx.c();
-        Timestamp[]input=new Timestamp[50];
+        Instant[]input=new Instant[50];
         for(int i=0;i<input.length;i++)
-            input[i]=new Timestamp(1);
+            input[i]=Instant.ofEpochMilli(1);
         try{
-            assertTrue(Arrays.equals(input,(Timestamp[])c.deserialize(c.serialize(1,input,false))));
-            assertTrue(Arrays.equals(input,(Timestamp[])c.deserialize(c.serialize(1,input,true))));
+            assertTrue(Arrays.equals(input,(Instant[])c.deserialize(c.serialize(1,input,false))));
+            assertTrue(Arrays.equals(input,(Instant[])c.deserialize(c.serialize(1,input,true))));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
@@ -733,16 +755,17 @@ public class cTest
     public void testSerializeDeserializeUtilDateArray()
     {
         kx.c c=new kx.c();
-        java.util.Date[]input=new java.util.Date[50];
+        LocalDateTime[]input=new LocalDateTime[50];
         try{
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
             for(int i=0;i<input.length;i++)
-                input[i]=new java.text.SimpleDateFormat("dd/MM/yyyy").parse("01/01/1990");
+                input[i]=LocalDate.parse("1990-01-01", formatter).atStartOfDay();
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
         try{
-            assertTrue(Arrays.equals(input,(java.util.Date[])c.deserialize(c.serialize(1,input,false))));
-            assertTrue(Arrays.equals(input,(java.util.Date[])c.deserialize(c.serialize(1,input,true))));
+            assertTrue(Arrays.equals(input,(LocalDateTime[])c.deserialize(c.serialize(1,input,false))));
+            assertTrue(Arrays.equals(input,(LocalDateTime[])c.deserialize(c.serialize(1,input,true))));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }


### PR DESCRIPTION
java.sql.Date > LocalDate  
java.sql.Time > LocalTime (only milli support)
java.sql.Timestamp > Instant 
java.util.Date > LocalDateTime (only milli support)