### PR TITLE
Provide files with checksums. Closes #66

### DIFF
--- a/javakdb-examples/pom.xml
+++ b/javakdb-examples/pom.xml
@@ -95,6 +95,34 @@
           </descriptorRefs>
         </configuration>
       </plugin>
+        <plugin>
+          <groupId>net.ju-n.maven.plugins</groupId>
+          <artifactId>checksum-maven-plugin</artifactId>
+          <version>1.3</version>
+          <executions>
+              <execution>
+                  <id>checksum-maven-plugin-files</id>
+                  <phase>package</phase>
+                  <goals>
+                      <goal>files</goal>
+                  </goals>
+              </execution>
+          </executions>
+          <configuration>
+              <fileSets>
+                  <fileSet>
+                  <directory>${project.build.directory}</directory>
+                  <includes>
+                      <include>*.jar</include>
+                  </includes>
+                  </fileSet>
+              </fileSets>
+              <algorithms>
+                  <algorithm>SHA-1</algorithm>
+                  <algorithm>MD5</algorithm>
+              </algorithms>
+          </configuration>
+        </plugin>
      </plugins>
   </build>
 

--- a/javakdb/pom.xml
+++ b/javakdb/pom.xml
@@ -125,6 +125,34 @@
               </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>net.ju-n.maven.plugins</groupId>
+          <artifactId>checksum-maven-plugin</artifactId>
+          <version>1.3</version>
+          <executions>
+              <execution>
+                  <id>checksum-maven-plugin-files</id>
+                  <phase>package</phase>
+                  <goals>
+                      <goal>files</goal>
+                  </goals>
+              </execution>
+          </executions>
+          <configuration>
+              <fileSets>
+                  <fileSet>
+                  <directory>${project.build.directory}</directory>
+                  <includes>
+                      <include>*.jar</include>
+                  </includes>
+                  </fileSet>
+              </fileSets>
+              <algorithms>
+                  <algorithm>SHA-1</algorithm>
+                  <algorithm>MD5</algorithm>
+              </algorithms>
+          </configuration>
+        </plugin>
       </plugins>
   </build>
 


### PR DESCRIPTION
Provide md5/sha1 files for each jar - required for upload to central maven repos.