### PR TITLE
changes for UDS (unix domain socket) client #72

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <jacoco.version>0.8.8</jacoco.version>
+    <jacoco.version>0.8.11</jacoco.version>
     <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
     <sonar.language>java</sonar.language>


### PR DESCRIPTION
Requires java version 16 (or greater) for UDS support.
Using reflection so still builds on versions <16 (i.e. looks up required classes at runtime)
Will throw an exception on trying to use UDS on versions <16.
Current change for java client talking to kdb+ server only, not java acting as kdb+ server with uds comms (may look at that in subsequent change)