### PR TITLE
try newer jdk due to sonar error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 os: linux
-dist: xenial
+dist: jammy
 jdk:
-    - oraclejdk11
+    - openjdk17
 addons:
     sonarcloud:
         organization: "kxsystems"


### PR DESCRIPTION
prev travis build says:
Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.11.0.3922:sonar (default-cli) on project JavaKdbModules: The plugin [python] does not support Java 11.0.23: org/sonar/plugins/python/PythonPlugin has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0 -> [Help 1]