### PR TITLE
update junit due to vunerability

### DIFF
--- a/javakdb/pom.xml
+++ b/javakdb/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>[4.13.1,)</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
github dependabot reporting:
The JUnit4 test rule TemporaryFolder contains a local information disclosure vulnerability.

Upgrade junit:junit to version 4.13.1 or later. For example:

<dependency>
  <groupId>junit</groupId>
  <artifactId>junit</artifactId>
  <version>[4.13.1,)</version>
</dependency>