### PR TITLE
Fix deserializing LocalTime negative and above 24:00 (issue #88)

### DIFF
--- a/javakdb/src/main/java/com/kx/c.java
+++ b/javakdb/src/main/java/com/kx/c.java
@@ -998,7 +998,8 @@ public class c{
    */
   LocalTime rt(){
     int timeAsInt=ri();
-    return (timeAsInt==ni?LOCAL_TIME_NULL:LocalTime.ofNanoOfDay(timeAsInt*1_000_000L));
+    // 86,400,00 is the max ms for LocalTime (24:00:00), after that we circle back to 00:00:00
+    return (timeAsInt==ni?LOCAL_TIME_NULL:LocalTime.ofNanoOfDay((Math.abs(timeAsInt) % 86_400_000) * 1_000_000L));
   }
   /**
    * Write LocalTime to serialization buffer in big endian format

--- a/javakdb/src/test/java/com/kx/CTest.java
+++ b/javakdb/src/test/java/com/kx/CTest.java
@@ -2,6 +2,7 @@ package com.kx;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.UnsupportedEncodingException;
 import java.util.UUID;
 import java.util.Arrays;
 import java.time.LocalTime;
@@ -435,6 +436,26 @@ public class CTest
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
+    }
+
+    @Test
+    public void testDeserializeTimeBeyond24Hours() throws c.KException, UnsupportedEncodingException {
+        // Serialized payload: 43:12:34.567 => 155,554,567ms
+        byte[] incomingMsg = new byte[]{1, 2, 0, 0, 13, 0, 0, 0, -19, 7, -109, 69, 9};
+        com.kx.c c = new com.kx.c();
+        LocalTime actual = (LocalTime) c.deserialize(incomingMsg);
+        LocalTime expected = LocalTime.of(19, 12, 34, 567_000_000);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testDeserializeTimeNegative() throws c.KException, UnsupportedEncodingException {
+        // Serialized payload: -23:12:34.567 -> -83,554,567ms
+        byte[] payload = new byte[]{1, 2, 0, 0, 13, 0, 0, 0, -19, -7, 14, 5, -5};
+        com.kx.c c = new com.kx.c();
+        LocalTime actual = (LocalTime) c.deserialize(payload);
+        LocalTime expected = LocalTime.of(23, 12, 34, 567_000_000);
+        Assert.assertEquals(expected, actual);
     }
 
     @Test


### PR DESCRIPTION
## Issue

 #88

When deserializing a Q `time` type, the Java deserializer does not handle when the time is above or equal to 24:00:00. It also does not handle when the time is negative.

## Implementation

The above 24hr time issue is handled by circling back to 00:00:00 using a modulo operator.

The negative time issue is handled by using an absolute value.

Unit tests were added for both changes.

